### PR TITLE
MV3: bind popup handlers, fix task rendering and notification icon

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,6 @@
 // background.js — Управление уведомлениями
+const NOTIFY_ICON = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y0X58QAAAAASUVORK5CYII=';
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'clear') {
     // Очистка всех текущих браузерных уведомлений
@@ -8,15 +10,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     // Возвращаем контроль системе (разрешаем показ новых)
     sendResponse({ status: 'allowed' });
   }
-  return true; // Keep channel open for async if needed
+  return true;
 });
 
-// Запрос permissions при первом запуске (опционально)
 chrome.runtime.onInstalled.addListener(() => {
   chrome.notifications.create('init', {
     type: 'basic',
     title: '🪼 Jelly Focus установлен!',
     message: 'Откройте всплывающее окно, чтобы начать первую сессию.',
-    iconUrl: ''
+    iconUrl: NOTIFY_ICON
   });
 });

--- a/popup.html
+++ b/popup.html
@@ -17,7 +17,7 @@
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); width: 320px; padding: 16px; transition: background 0.5s; }
   h1, h2, h3 { font-family: 'Orbitron', sans-serif; }
-  
+
   /* Медуза (Pure CSS) */
   .jelly-wrap { position: relative; height: 100px; margin: 10px auto; display: flex; justify-content: center; }
   .jelly { width: 70px; height: 60px; background: linear-gradient(180deg, var(--cur), transparent); border-radius: 50% 50% 40% 40%; position: relative; animation: swim 4s ease-in-out infinite; box-shadow: 0 0 25px var(--cur-glow); transition: all 0.5s; }
@@ -36,7 +36,7 @@
   .time { font-family: 'Orbitron'; font-size: 3.2rem; font-weight: 700; text-shadow: 0 0 15px var(--cur-glow); transition: text-shadow 0.5s; }
   .progress-bg { width: 100%; height: 6px; background: var(--border); border-radius: 3px; margin-top: 8px; overflow: hidden; }
   .progress-bar { height: 100%; background: var(--cur); transition: width 1s linear; box-shadow: 0 0 10px var(--cur); }
-  
+
   .controls { display: flex; gap: 8px; justify-content: center; margin: 12px 0; }
   .btn { background: rgba(255,255,255,0.05); border: 1px solid var(--border); color: var(--text); padding: 8px 14px; border-radius: var(--rad); cursor: pointer; font-size: 0.85rem; transition: 0.2s; }
   .btn:hover { background: rgba(255,255,255,0.1); border-color: var(--cur); }
@@ -61,13 +61,13 @@
   .task { display: flex; align-items: center; gap: 8px; padding: 6px; background: rgba(255,255,255,0.02); border-radius: 6px; margin-bottom: 4px; transition: 0.2s; font-size: 0.85rem; }
   .task.done { opacity: 0.4; text-decoration: line-through; }
   .task:hover { background: rgba(255,255,255,0.05); }
-  .check { width: 18px; height: 18px; border: 2px solid var(--border); border-radius: 4px; cursor: pointer; flex-shrink: 0; display: grid; place-items: transition: 0.2s; }
+  .check { width: 18px; height: 18px; border: 2px solid var(--border); border-radius: 4px; cursor: pointer; flex-shrink: 0; display: grid; place-items: center; transition: 0.2s; }
   .check.ok { background: var(--cur); border-color: var(--cur); }
   .check.ok::after { content: '✓'; font-size: 12px; color: var(--bg); }
   .del { margin-left: auto; background: transparent; border: none; color: var(--sub); cursor: pointer; font-size: 1rem; opacity: 0.5; }
   .del:hover { opacity: 1; color: #ff5757; }
   .empty { text-align: center; color: var(--sub); opacity: 0.5; font-size: 0.8rem; padding: 10px; }
-  
+
   /* Настройки времени */
   .settings { display: flex; gap: 8px; justify-content: center; margin-top: 8px; font-size: 0.75rem; color: var(--sub); }
   .s-btn { background: transparent; border: 1px solid var(--border); color: var(--text); width: 24px; height: 24px; border-radius: 4px; cursor: pointer; }
@@ -123,13 +123,13 @@
 
   <div class="settings">
     <span>Работа</span>
-    <button class="s-btn" onclick="adjTime('w',-1)">-</button>
+    <button class="s-btn" id="workMinus">-</button>
     <span class="s-val" id="wVal">25</span>
-    <button class="s-btn" onclick="adjTime('w',1)">+</button>
+    <button class="s-btn" id="workPlus">+</button>
     <span style="margin-left:8px">Отдых</span>
-    <button class="s-btn" onclick="adjTime('r',-1)">-</button>
+    <button class="s-btn" id="restMinus">-</button>
     <span class="s-val" id="rVal">5</span>
-    <button class="s-btn" onclick="adjTime('r',1)">+</button>
+    <button class="s-btn" id="restPlus">+</button>
   </div>
 
   <div class="lvl-up" id="lvlAnim">⬆ LEVEL UP!</div>

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,8 @@
 // popup.js — Вся логика интерфейса и таймера
 const $ = id => document.getElementById(id);
+const NOTIFY_ICON = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y0X58QAAAAASUVORK5CYII=';
 const state = {
-  running: false, work: true, timeLeft: 25*60, total: 25*60,
+  running: false, work: true, timeLeft: 25 * 60, total: 25 * 60,
   workDur: 25, restDur: 5,
   xp: 0, level: 1, nextLvl: 100, streak: 0, doneTasks: 0,
   tasks: [], interval: null
@@ -11,10 +12,59 @@ const state = {
 async function init() {
   const saved = await chrome.storage.local.get(['state']);
   if (saved.state) Object.assign(state, saved.state);
-  state.timeLeft = state.work ? state.workDur*60 : state.restDur*60;
+
+  state.running = false;
+  state.interval = null;
+  state.timeLeft = state.work ? state.workDur * 60 : state.restDur * 60;
   state.total = state.timeLeft;
-  $(`wVal`).textContent = state.workDur; $(`rVal`).textContent = state.restDur;
-  renderTasks(); updateXP(); applyTheme(); updateDisplay();
+
+  $('wVal').textContent = state.workDur;
+  $('rVal').textContent = state.restDur;
+
+  bindControls();
+  renderTasks();
+  updateXP();
+  applyTheme();
+  updateDisplay();
+}
+
+function bindControls() {
+  $('btnStart').onclick = () => {
+    if (state.running) {
+      state.running = false;
+      clearInterval(state.interval);
+      $('btnStart').textContent = '▶ Старт';
+      sendBG('allow');
+    } else {
+      state.running = true;
+      $('btnStart').textContent = '⏸ Пауза';
+      state.interval = setInterval(tick, 1000);
+      if (state.work) sendBG('clear');
+    }
+  };
+
+  $('btnReset').onclick = () => {
+    state.running = false;
+    clearInterval(state.interval);
+    state.work = true;
+    state.timeLeft = state.workDur * 60;
+    state.total = state.timeLeft;
+    $('btnStart').textContent = '▶ Старт';
+    applyTheme();
+    updateDisplay();
+    saveState();
+    sendBG('allow');
+  };
+
+  $('btnAdd').onclick = addTask;
+  $('taskIn').onkeydown = e => {
+    if (e.key === 'Enter') addTask();
+  };
+
+  $('workMinus').onclick = () => adjTime('w', -1);
+  $('workPlus').onclick = () => adjTime('w', 1);
+  $('restMinus').onclick = () => adjTime('r', -1);
+  $('restPlus').onclick = () => adjTime('r', 1);
 }
 
 function applyTheme() {
@@ -22,20 +72,23 @@ function applyTheme() {
   if (state.work) {
     root.style.setProperty('--cur', 'var(--neon-work)');
     root.style.setProperty('--cur-glow', 'var(--neon-work-glow)');
-    $('jelly').classList.remove('rest'); $('phaseTxt').textContent = 'ФОКУС';
+    $('jelly').classList.remove('rest');
+    $('phaseTxt').textContent = 'ФОКУС';
   } else {
     root.style.setProperty('--cur', 'var(--neon-rest)');
     root.style.setProperty('--cur-glow', 'var(--neon-rest-glow)');
-    $('jelly').classList.add('rest'); $('phaseTxt').textContent = 'ОТДЫХ';
+    $('jelly').classList.add('rest');
+    $('phaseTxt').textContent = 'ОТДЫХ';
   }
 }
 
 function updateDisplay() {
-  const m = String(Math.floor(state.timeLeft/60)).padStart(2,'0');
-  const s = String(state.timeLeft%60).padStart(2,'0');
+  const m = String(Math.floor(state.timeLeft / 60)).padStart(2, '0');
+  const s = String(state.timeLeft % 60).padStart(2, '0');
   const t = `${m}:${s}`;
   $('timeDisp').textContent = t;
-  $('progBar').style.width = `${(state.timeLeft/state.total)*100}%`;
+  const width = state.total > 0 ? (state.timeLeft / state.total) * 100 : 0;
+  $('progBar').style.width = `${Math.max(0, width)}%`;
   document.title = `${t} | ${state.work ? '💜 Фокус' : '💚 Отдых'}`;
 }
 
@@ -46,93 +99,127 @@ function tick() {
 }
 
 function switchPhase() {
-  clearInterval(state.interval); state.running = false; $('btnStart').textContent = '▶ Старт';
+  clearInterval(state.interval);
+  state.running = false;
+  $('btnStart').textContent = '▶ Старт';
+
   playSound(state.work ? 'complete' : 'restEnd');
   if (state.work) {
-    state.streak++; state.xp += 50;
+    state.streak++;
+    state.xp += 50;
     showToast('🎉 Помодор завершён! +50 XP');
   } else {
     showToast('☕ Отдых окончен!');
   }
+
   state.work = !state.work;
-  state.timeLeft = state.work ? state.workDur*60 : state.restDur*60;
+  state.timeLeft = state.work ? state.workDur * 60 : state.restDur * 60;
   state.total = state.timeLeft;
-  applyTheme(); updateDisplay(); checkLevelUp(); saveState();
-  // Управление уведомлениями
-  if (state.work) sendBG('clear'); else sendBG('allow');
+
+  applyTheme();
+  updateDisplay();
+  checkLevelUp();
+  saveState();
+
+  if (state.work) sendBG('clear');
+  else sendBG('allow');
 }
 
-$('btnStart').onclick = () => {
-  if (state.running) {
-    state.running = false; clearInterval(state.interval); $('btnStart').textContent = '▶ Старт';
-    sendBG('allow');
-  } else {
-    state.running = true; $('btnStart').textContent = '⏸ Пауза';
-    state.interval = setInterval(tick, 1000);
-    if (state.work) sendBG('clear'); // Очистка при старте работы
-  }
-};
-
-$('btnReset').onclick = () => {
-  state.running = false; clearInterval(state.interval);
-  state.work = true; state.timeLeft = state.workDur*60; state.total = state.timeLeft;
-  $('btnStart').textContent = '▶ Старт'; applyTheme(); updateDisplay(); sendBG('allow');
-};
-
 function adjTime(type, d) {
-  if (type==='w') { state.workDur = Math.max(5, Math.min(60, state.workDur+d)); $('wVal').textContent = state.workDur; }
-  else { state.restDur = Math.max(1, Math.min(30, state.restDur+d)); $('rVal').textContent = state.restDur; }
-  if (!state.running && (type==='w' && state.work || type==='r' && !state.work)) {
-    state.timeLeft = (type==='w' ? state.workDur : state.restDur)*60;
-    state.total = state.timeLeft; updateDisplay();
+  if (type === 'w') {
+    state.workDur = Math.max(5, Math.min(60, state.workDur + d));
+    $('wVal').textContent = state.workDur;
+  } else {
+    state.restDur = Math.max(1, Math.min(30, state.restDur + d));
+    $('rVal').textContent = state.restDur;
   }
+
+  if (!state.running && ((type === 'w' && state.work) || (type === 'r' && !state.work))) {
+    state.timeLeft = (type === 'w' ? state.workDur : state.restDur) * 60;
+    state.total = state.timeLeft;
+    updateDisplay();
+  }
+
   saveState();
 }
 
 // Задачи
 function renderTasks() {
   const list = $('taskList');
-  const done = state.tasks.filter(t=>t.done).length;
-  $('taskCount').textContent = `${done} / ${state.tasks.length}`; $('doneTasks').textContent = state.doneTasks;
-  if (!state.tasks.length) { list.innerHTML = '<div class="empty">Нет задач. Добавьте первую! 🎯</div>'; return; }
+  const done = state.tasks.filter(t => t.done).length;
+  $('taskCount').textContent = `${done} / ${state.tasks.length}`;
+  $('doneTasks').textContent = state.doneTasks;
+
+  if (!state.tasks.length) {
+    list.innerHTML = '<div class="empty">Нет задач. Добавьте первую! 🎯</div>';
+    return;
+  }
+
   list.innerHTML = state.tasks.map(t => `
-    <div class="task ${t.done?'done':''}" data-id="${t.id}">
-      <div class="check ${t.done?'ok':''}" onclick="toggleTask(${t.id})"></div>
+    <div class="task ${t.done ? 'done' : ''}" data-id="${t.id}">
+      <button class="check ${t.done ? 'ok' : ''}" data-action="toggle" data-id="${t.id}" aria-label="Переключить задачу"></button>
       <span style="flex:1;overflow:hidden;white-space:nowrap">${esc(t.text)}</span>
-      <button class="del" onclick="delTask(${t.id})">✕</button>
+      <button class="del" data-action="delete" data-id="${t.id}" aria-label="Удалить задачу">✕</button>
     </div>
   `).join('');
+
+  list.querySelectorAll('[data-action="toggle"]').forEach(btn => {
+    btn.addEventListener('click', () => toggleTask(Number(btn.dataset.id)));
+  });
+  list.querySelectorAll('[data-action="delete"]').forEach(btn => {
+    btn.addEventListener('click', () => delTask(Number(btn.dataset.id)));
+  });
 }
+
 function addTask() {
-  const v = $('taskIn').value.trim(); if (!v) return;
-  state.tasks.push({id: Date.now(), text: v, done: false});
-  $('taskIn').value = ''; renderTasks(); saveState();
+  const v = $('taskIn').value.trim();
+  if (!v) return;
+
+  state.tasks.push({ id: Date.now(), text: v, done: false });
+  $('taskIn').value = '';
+  renderTasks();
+  saveState();
 }
-window.toggleTask = id => {
-  const t = state.tasks.find(x=>x.id===id); if (!t) return;
-  t.done = !t.done; state.doneTasks += t.done ? 1 : -1;
-  if (t.done) { state.xp += 15; checkLevelUp(); }
-  renderTasks(); updateXP(); saveState();
-};
-window.delTask = id => {
-  state.tasks = state.tasks.filter(x=>x.id!==id); renderTasks(); saveState();
-};
-$('btnAdd').onclick = addTask;
-$('taskIn').onkeydown = e => { if(e.key==='Enter') addTask(); };
+
+function toggleTask(id) {
+  const t = state.tasks.find(x => x.id === id);
+  if (!t) return;
+
+  t.done = !t.done;
+  state.doneTasks += t.done ? 1 : -1;
+  if (t.done) {
+    state.xp += 15;
+    checkLevelUp();
+  }
+
+  renderTasks();
+  updateXP();
+  saveState();
+}
+
+function delTask(id) {
+  state.tasks = state.tasks.filter(x => x.id !== id);
+  renderTasks();
+  saveState();
+}
 
 // Геймификация
 function checkLevelUp() {
   while (state.xp >= state.nextLvl) {
-    state.xp -= state.nextLvl; state.level++; state.nextLvl = Math.floor(state.nextLvl * 1.3);
-    $('lvlAnim').classList.add('show'); playSound('levelup');
+    state.xp -= state.nextLvl;
+    state.level++;
+    state.nextLvl = Math.floor(state.nextLvl * 1.3);
+    $('lvlAnim').classList.add('show');
+    playSound('levelup');
     setTimeout(() => $('lvlAnim').classList.remove('show'), 1200);
   }
   updateXP();
 }
+
 function updateXP() {
   $('lvlDisp').textContent = `Ур. ${state.level}`;
   $('xpDisp').textContent = `${state.xp} / ${state.nextLvl} XP`;
-  $('xpFill').style.width = `${(state.xp/state.nextLvl)*100}%`;
+  $('xpFill').style.width = `${(state.xp / state.nextLvl) * 100}%`;
   $('streak').textContent = state.streak;
 }
 
@@ -140,22 +227,40 @@ function updateXP() {
 const actx = new (window.AudioContext || window.webkitAudioContext)();
 function playSound(type) {
   const now = actx.currentTime;
-  const g = actx.createGain(); g.connect(actx.destination);
-  if (type==='complete') [523.25, 659.25, 783.99].forEach((f,i)=>{
-    const o = actx.createOscillator(); o.type='sine'; o.frequency.value=f;
-    o.connect(g); o.start(now+i*0.15); g.gain.setValueAtTime(0.1, now+i*0.15);
-    g.gain.exponentialRampToValueAtTime(0.001, now+i*0.15+0.5); o.stop(now+i*0.15+0.5);
-  });
-  else if (type==='restEnd') {
-    const o = actx.createOscillator(); o.type='triangle'; o.frequency.setValueAtTime(440, now);
-    o.frequency.linearRampToValueAtTime(880, now+0.3); o.connect(g); o.start(now);
-    g.gain.setValueAtTime(0.12, now); g.gain.exponentialRampToValueAtTime(0.001, now+0.5); o.stop(now+0.5);
-  }
-  else if (type==='levelup') {
-    [600, 800, 1000, 1200].forEach((f,i)=>{
-      const o = actx.createOscillator(); o.type='sine'; o.frequency.value=f; o.connect(g);
-      o.start(now+i*0.1); g.gain.setValueAtTime(0.15, now+i*0.1);
-      g.gain.exponentialRampToValueAtTime(0.001, now+i*0.1+0.4); o.stop(now+i*0.1+0.4);
+  const g = actx.createGain();
+  g.connect(actx.destination);
+
+  if (type === 'complete') {
+    [523.25, 659.25, 783.99].forEach((f, i) => {
+      const o = actx.createOscillator();
+      o.type = 'sine';
+      o.frequency.value = f;
+      o.connect(g);
+      o.start(now + i * 0.15);
+      g.gain.setValueAtTime(0.1, now + i * 0.15);
+      g.gain.exponentialRampToValueAtTime(0.001, now + i * 0.15 + 0.5);
+      o.stop(now + i * 0.15 + 0.5);
+    });
+  } else if (type === 'restEnd') {
+    const o = actx.createOscillator();
+    o.type = 'triangle';
+    o.frequency.setValueAtTime(440, now);
+    o.frequency.linearRampToValueAtTime(880, now + 0.3);
+    o.connect(g);
+    o.start(now);
+    g.gain.setValueAtTime(0.12, now);
+    g.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
+    o.stop(now + 0.5);
+  } else if (type === 'levelup') {
+    [600, 800, 1000, 1200].forEach((f, i) => {
+      const o = actx.createOscillator();
+      o.type = 'sine';
+      o.frequency.value = f;
+      o.connect(g);
+      o.start(now + i * 0.1);
+      g.gain.setValueAtTime(0.15, now + i * 0.1);
+      g.gain.exponentialRampToValueAtTime(0.001, now + i * 0.1 + 0.4);
+      o.stop(now + i * 0.1 + 0.4);
     });
   }
 }
@@ -164,11 +269,24 @@ function playSound(type) {
 function sendBG(action) {
   chrome.runtime.sendMessage({ action });
 }
-function showToast(msg) {
-  chrome.notifications?.create({ type:'basic', title:'Jelly Focus', message: msg, iconUrl:'' });
-}
-function esc(str) { const d=document.createElement('div'); d.textContent=str; return d.innerHTML; }
 
-async function saveState() { chrome.storage.local.set({ state }); }
+function showToast(msg) {
+  chrome.notifications?.create({
+    type: 'basic',
+    title: 'Jelly Focus',
+    message: msg,
+    iconUrl: NOTIFY_ICON
+  });
+}
+
+function esc(str) {
+  const d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
+}
+
+async function saveState() {
+  chrome.storage.local.set({ state });
+}
 
 init();


### PR DESCRIPTION
### Motivation
- Ensure the popup is compatible with Manifest V3 CSP by removing inline `onclick` handlers and moving all UI binding into JS. 
- Prevent runtime failures from `chrome.notifications.create` when `iconUrl` is empty by providing a safe inline data-URL. 
- Improve robustness and accessibility of task controls and avoid fragile inline handlers. 
- Fix minor UI bugs (checkbox layout) and guard progress calculations against division by zero.

### Description
- Replaced inline `onclick` controls in `popup.html` with `id` attributes and bound all interactions in `popup.js` via a new `bindControls()` function. 
- Rewrote task rendering to emit action buttons with `data-*` attributes and attach `addEventListener` handlers instead of inline `onclick`, and converted `toggleTask`/`delTask` to named functions. 
- Added a `NOTIFY_ICON` data-URL and used it as `iconUrl` in both `popup.js` and `background.js` to avoid empty-icon notification errors. 
- Corrected CSS for the checkbox (`.check { place-items: center; }`), added a safe guard for progress bar width (`state.total > 0`) and cleaned up initialization/state handling for the timer. 

### Testing
- Ran JavaScript syntax checks with `node --check popup.js` and `node --check background.js`, both succeeded. 
- Validated `manifest.json` syntax with `python -m json.tool manifest.json`, which succeeded. 
- No automated UI/browser tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdedf186d8832598003d38164278cb)