### PR TITLE
Replace popup.html with full Jelly Focus Pomodoro UI

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -3,136 +3,1468 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Jelly Focus</title>
+<title>🪼 Jelly Focus — Pomodoro Timer</title>
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Inter:wght@300;400;600&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Inter:wght@300;400;500;600&display=swap');
+
   :root {
-    --bg: #0a0a14; --panel: #111122; --border: rgba(255,255,255,0.08);
-    --neon-work: #b84aff; --neon-work-glow: rgba(184,74,255,0.4);
-    --neon-rest: #00ffd5; --neon-rest-glow: rgba(0,255,213,0.4);
-    --neon-gold: #ffd700; --text: #e8e8f0; --sub: #8888aa;
-    --cur: var(--neon-work); --cur-glow: var(--neon-work-glow);
-    --rad: 12px;
+    --bg-primary: #0a0a1a;
+    --bg-secondary: #111128;
+    --bg-card: rgba(20, 20, 50, 0.6);
+    --neon-work: #b44aff;
+    --neon-work-glow: rgba(180, 74, 255, 0.4);
+    --neon-rest: #00ffd5;
+    --neon-rest-glow: rgba(0, 255, 213, 0.4);
+    --neon-accent: #ff6b9d;
+    --neon-gold: #ffd700;
+    --text-primary: #e8e8f0;
+    --text-secondary: #8888aa;
+    --neon-current: var(--neon-work);
+    --neon-glow: var(--neon-work-glow);
+    --transition-speed: 1s;
   }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: 'Inter', sans-serif; background: var(--bg); color: var(--text); width: 320px; padding: 16px; transition: background 0.5s; }
-  h1, h2, h3 { font-family: 'Orbitron', sans-serif; }
 
-  /* Медуза (Pure CSS) */
-  .jelly-wrap { position: relative; height: 100px; margin: 10px auto; display: flex; justify-content: center; }
-  .jelly { width: 70px; height: 60px; background: linear-gradient(180deg, var(--cur), transparent); border-radius: 50% 50% 40% 40%; position: relative; animation: swim 4s ease-in-out infinite; box-shadow: 0 0 25px var(--cur-glow); transition: all 0.5s; }
-  .jelly::before, .jelly::after { content: ''; position: absolute; width: 12px; height: 12px; background: #fff; border-radius: 50%; top: 20px; box-shadow: 0 0 8px #fff; }
-  .jelly::before { left: 15px; } .jelly::after { right: 15px; }
-  .jelly.rest { --cur: var(--neon-rest); --cur-glow: var(--neon-rest-glow); }
-  @keyframes swim { 0%,100% { transform: translateY(0) scale(1); } 50% { transform: translateY(-8px) scale(1.05); } }
-  .tentacles { position: absolute; bottom: -25px; left: 50%; transform: translateX(-50%); display: flex; gap: 6px; }
-  .ten { width: 3px; height: 18px; background: var(--cur); border-radius: 2px; opacity: 0.7; animation: wave 2s infinite alternate; transition: background 0.5s; }
-  .ten:nth-child(odd) { animation-delay: 0.2s; }
-  @keyframes wave { 0% { transform: skewX(-10deg); } 100% { transform: skewX(10deg); } }
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
 
-  /* Таймер */
-  .timer-ui { text-align: center; margin: 10px 0; }
-  .phase { font-size: 0.7rem; color: var(--cur); letter-spacing: 3px; text-transform: uppercase; margin-bottom: 4px; transition: color 0.5s; }
-  .time { font-family: 'Orbitron'; font-size: 3.2rem; font-weight: 700; text-shadow: 0 0 15px var(--cur-glow); transition: text-shadow 0.5s; }
-  .progress-bg { width: 100%; height: 6px; background: var(--border); border-radius: 3px; margin-top: 8px; overflow: hidden; }
-  .progress-bar { height: 100%; background: var(--cur); transition: width 1s linear; box-shadow: 0 0 10px var(--cur); }
+  body {
+    font-family: 'Inter', sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    min-height: 100vh;
+    overflow-x: hidden;
+    transition: background var(--transition-speed);
+  }
 
-  .controls { display: flex; gap: 8px; justify-content: center; margin: 12px 0; }
-  .btn { background: rgba(255,255,255,0.05); border: 1px solid var(--border); color: var(--text); padding: 8px 14px; border-radius: var(--rad); cursor: pointer; font-size: 0.85rem; transition: 0.2s; }
-  .btn:hover { background: rgba(255,255,255,0.1); border-color: var(--cur); }
-  .btn.primary { background: linear-gradient(135deg, var(--cur), #ff6b9d); border: none; color: #fff; font-weight: 600; }
-  .btn.primary:hover { transform: translateY(-1px); box-shadow: 0 4px 15px var(--cur-glow); }
+  /* ===== ФОНОВЫЕ ЧАСТИЦЫ ===== */
+  .particles-bg {
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    pointer-events: none;
+    z-index: 0;
+    overflow: hidden;
+  }
 
-  /* Геймификация */
-  .xp-wrap { background: rgba(255,255,255,0.03); padding: 8px 10px; border-radius: var(--rad); margin-bottom: 12px; }
-  .xp-meta { display: flex; justify-content: space-between; font-size: 0.7rem; color: var(--sub); margin-bottom: 4px; }
-  .xp-bar { height: 4px; background: rgba(255,255,255,0.05); border-radius: 2px; }
-  .xp-fill { height: 100%; width: 0%; background: var(--neon-gold); border-radius: 2px; transition: width 0.4s; box-shadow: 0 0 8px rgba(255,215,0,0.4); }
-  .stats { display: flex; gap: 8px; margin-bottom: 10px; font-size: 0.75rem; }
-  .stat { background: rgba(255,255,255,0.03); padding: 4px 8px; border-radius: 6px; color: var(--sub); flex: 1; text-align: center; }
-  .stat span { color: var(--neon-gold); font-weight: 600; }
+  .particle {
+    position: absolute;
+    border-radius: 50%;
+    background: var(--neon-current);
+    opacity: 0.08;
+    animation: floatParticle linear infinite;
+    transition: background var(--transition-speed);
+  }
 
-  /* Задачи */
-  .tasks-h { display: flex; justify-content: space-between; align-items: center; font-size: 0.9rem; margin-bottom: 6px; color: var(--sub); }
-  .task-inputs { display: flex; gap: 6px; margin-bottom: 8px; }
-  .task-inputs input { flex: 1; background: rgba(255,255,255,0.04); border: 1px solid var(--border); padding: 8px; border-radius: 8px; color: #fff; font-size: 0.85rem; }
-  .task-inputs input:focus { outline: none; border-color: var(--cur); }
-  .task-list { max-height: 110px; overflow-y: auto; padding-right: 2px; }
-  .task { display: flex; align-items: center; gap: 8px; padding: 6px; background: rgba(255,255,255,0.02); border-radius: 6px; margin-bottom: 4px; transition: 0.2s; font-size: 0.85rem; }
-  .task.done { opacity: 0.4; text-decoration: line-through; }
-  .task:hover { background: rgba(255,255,255,0.05); }
-  .check { width: 18px; height: 18px; border: 2px solid var(--border); border-radius: 4px; cursor: pointer; flex-shrink: 0; display: grid; place-items: center; transition: 0.2s; }
-  .check.ok { background: var(--cur); border-color: var(--cur); }
-  .check.ok::after { content: '✓'; font-size: 12px; color: var(--bg); }
-  .del { margin-left: auto; background: transparent; border: none; color: var(--sub); cursor: pointer; font-size: 1rem; opacity: 0.5; }
-  .del:hover { opacity: 1; color: #ff5757; }
-  .empty { text-align: center; color: var(--sub); opacity: 0.5; font-size: 0.8rem; padding: 10px; }
+  @keyframes floatParticle {
+    0% { transform: translateY(100vh) rotate(0deg); opacity: 0; }
+    10% { opacity: 0.08; }
+    90% { opacity: 0.08; }
+    100% { transform: translateY(-10vh) rotate(360deg); opacity: 0; }
+  }
 
-  /* Настройки времени */
-  .settings { display: flex; gap: 8px; justify-content: center; margin-top: 8px; font-size: 0.75rem; color: var(--sub); }
-  .s-btn { background: transparent; border: 1px solid var(--border); color: var(--text); width: 24px; height: 24px; border-radius: 4px; cursor: pointer; }
-  .s-val { min-width: 20px; text-align: center; color: var(--cur); font-family: 'Orbitron'; }
+  /* ===== ОСНОВНОЙ КОНТЕЙНЕР ===== */
+  .app-container {
+    position: relative;
+    z-index: 1;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 24px;
+    min-height: 100vh;
+    align-content: start;
+  }
 
-  /* Level Up */
-  .lvl-up { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); font-family: 'Orbitron'; font-size: 2rem; font-weight: 700; color: var(--neon-gold); text-shadow: 0 0 30px rgba(255,215,0,0.6); pointer-events: none; opacity: 0; z-index: 999; }
-  .lvl-up.show { animation: pop 1.2s ease-out forwards; }
-  @keyframes pop { 0% { scale: 0; opacity: 0; } 30% { scale: 1.2; opacity: 1; } 60% { scale: 1; } 100% { transform: translate(-50%, -60%); opacity: 0; } }
+  /* ===== ШАПКА ===== */
+  .header {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 24px;
+    background: var(--bg-card);
+    border-radius: 16px;
+    border: 1px solid rgba(255,255,255,0.05);
+    backdrop-filter: blur(20px);
+  }
+
+  .header h1 {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 1.4rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, var(--neon-current), var(--neon-accent));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    transition: all var(--transition-speed);
+  }
+
+  .header-stats {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+  }
+
+  .stat-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    background: rgba(255,255,255,0.04);
+    border-radius: 20px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+
+  .stat-badge .stat-icon { font-size: 1rem; }
+  .stat-badge .stat-value {
+    font-family: 'Orbitron', sans-serif;
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  /* ===== СЕКЦИЯ МЕДУЗЫ И ТАЙМЕРА ===== */
+  .jelly-timer-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 30px;
+    background: var(--bg-card);
+    border-radius: 24px;
+    border: 1px solid rgba(255,255,255,0.05);
+    backdrop-filter: blur(20px);
+    min-height: 520px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .jelly-timer-section::before {
+    content: '';
+    position: absolute;
+    top: 50%; left: 50%;
+    width: 300px; height: 300px;
+    transform: translate(-50%, -50%);
+    background: radial-gradient(circle, var(--neon-glow) 0%, transparent 70%);
+    border-radius: 50%;
+    transition: background var(--transition-speed);
+    animation: bgPulse 4s ease-in-out infinite;
+  }
+
+  @keyframes bgPulse {
+    0%, 100% { transform: translate(-50%, -50%) scale(1); opacity: 0.3; }
+    50% { transform: translate(-50%, -50%) scale(1.2); opacity: 0.5; }
+  }
+
+  /* ===== МЕДУЗА (CSS) ===== */
+  .jellyfish-container {
+    position: relative;
+    width: 180px;
+    height: 220px;
+    margin-bottom: 10px;
+    z-index: 1;
+  }
+
+  .jellyfish {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    animation: jellyFloat 6s ease-in-out infinite;
+  }
+
+  @keyframes jellyFloat {
+    0%, 100% { transform: translateY(0) rotate(-1deg); }
+    25% { transform: translateY(-15px) rotate(1deg); }
+    50% { transform: translateY(-5px) rotate(-1deg); }
+    75% { transform: translateY(-20px) rotate(1deg); }
+  }
+
+  /* Купол медузы */
+  .jelly-dome {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 120px;
+    height: 90px;
+    background: linear-gradient(180deg,
+      var(--neon-current) 0%,
+      rgba(180, 74, 255, 0.3) 60%,
+      rgba(180, 74, 255, 0.1) 100%
+    );
+    border-radius: 60px 60px 40px 40px;
+    transition: background var(--transition-speed);
+    animation: domePulse 3s ease-in-out infinite;
+    box-shadow:
+      0 0 30px var(--neon-glow),
+      inset 0 -10px 20px rgba(0,0,0,0.3),
+      inset 0 5px 15px rgba(255,255,255,0.1);
+  }
+
+  .jelly-dome::after {
+    content: '';
+    position: absolute;
+    top: 12px; left: 20px;
+    width: 30px; height: 20px;
+    background: rgba(255,255,255,0.15);
+    border-radius: 50%;
+    transform: rotate(-20deg);
+  }
+
+  @keyframes domePulse {
+    0%, 100% {
+      transform: translateX(-50%) scaleX(1) scaleY(1);
+      height: 90px;
+    }
+    50% {
+      transform: translateX(-50%) scaleX(1.08) scaleY(0.92);
+      height: 85px;
+    }
+  }
+
+  /* Щупальца */
+  .tentacles {
+    position: absolute;
+    top: 85px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 130px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .tentacle {
+    width: 4px;
+    height: 100%;
+    position: relative;
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .tentacle::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(180deg,
+      var(--neon-current) 0%,
+      transparent 100%
+    );
+    border-radius: 2px;
+    transition: background var(--transition-speed);
+    animation: tentacleWave 3s ease-in-out infinite;
+    opacity: 0.7;
+  }
+
+  .tentacle:nth-child(1)::before { animation-delay: 0s; }
+  .tentacle:nth-child(2)::before { animation-delay: 0.3s; }
+  .tentacle:nth-child(3)::before { animation-delay: 0.6s; }
+  .tentacle:nth-child(4)::before { animation-delay: 0.9s; }
+  .tentacle:nth-child(5)::before { animation-delay: 1.2s; }
+
+  @keyframes tentacleWave {
+    0%, 100% { transform: translateX(0) rotate(0deg); }
+    25% { transform: translateX(8px) rotate(5deg); }
+    75% { transform: translateX(-8px) rotate(-5deg); }
+  }
+
+  .tentacle-long { height: 100%; }
+  .tentacle-short { height: 75%; }
+  .tentacle-tiny { height: 55%; }
+
+  /* Глаза медузы (для милоты) */
+  .jelly-eyes {
+    position: absolute;
+    top: 42px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 22px;
+    z-index: 2;
+  }
+
+  .jelly-eye {
+    width: 14px;
+    height: 14px;
+    background: rgba(255,255,255,0.9);
+    border-radius: 50%;
+    position: relative;
+    box-shadow: 0 0 8px rgba(255,255,255,0.3);
+  }
+
+  .jelly-eye::after {
+    content: '';
+    position: absolute;
+    top: 3px; left: 4px;
+    width: 6px; height: 6px;
+    background: var(--bg-primary);
+    border-radius: 50%;
+    transition: transform 0.3s;
+  }
+
+  .jellyfish.resting .jelly-eye::after {
+    transform: translateX(1px) translateY(1px);
+  }
+
+  .jelly-mouth {
+    position: absolute;
+    top: 58px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 10px;
+    height: 6px;
+    border-bottom: 2px solid rgba(255,255,255,0.5);
+    border-radius: 0 0 50% 50%;
+    z-index: 2;
+  }
+
+  /* ===== ТАЙМЕР ===== */
+  .timer-display {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    margin-top: 10px;
+  }
+
+  .timer-phase {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 4px;
+    color: var(--neon-current);
+    margin-bottom: 8px;
+    transition: color var(--transition-speed);
+  }
+
+  .timer-time {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 4rem;
+    font-weight: 900;
+    letter-spacing: 4px;
+    color: var(--text-primary);
+    text-shadow: 0 0 30px var(--neon-glow);
+    transition: text-shadow var(--transition-speed);
+    line-height: 1;
+  }
+
+  .timer-progress {
+    width: 200px;
+    height: 4px;
+    background: rgba(255,255,255,0.08);
+    border-radius: 2px;
+    margin: 16px auto;
+    overflow: hidden;
+  }
+
+  .timer-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--neon-current), var(--neon-accent));
+    border-radius: 2px;
+    transition: width 1s linear, background var(--transition-speed);
+    box-shadow: 0 0 10px var(--neon-glow);
+  }
+
+  /* ===== КНОПКИ УПРАВЛЕНИЯ ===== */
+  .timer-controls {
+    display: flex;
+    gap: 12px;
+    margin-top: 20px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .btn {
+    padding: 10px 24px;
+    border: none;
+    border-radius: 12px;
+    font-family: 'Inter', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.3s;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .btn-primary {
+    background: linear-gradient(135deg, var(--neon-current), var(--neon-accent));
+    color: white;
+    box-shadow: 0 4px 20px var(--neon-glow);
+    transition: all 0.3s, background var(--transition-speed), box-shadow var(--transition-speed);
+  }
+
+  .btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 30px var(--neon-glow);
+  }
+
+  .btn-secondary {
+    background: rgba(255,255,255,0.06);
+    color: var(--text-secondary);
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .btn-secondary:hover {
+    background: rgba(255,255,255,0.1);
+    color: var(--text-primary);
+  }
+
+  .btn:active { transform: translateY(0) scale(0.98); }
+
+  /* ===== ПАНЕЛЬ ЗАДАЧ ===== */
+  .tasks-section {
+    display: flex;
+    flex-direction: column;
+    padding: 24px;
+    background: var(--bg-card);
+    border-radius: 24px;
+    border: 1px solid rgba(255,255,255,0.05);
+    backdrop-filter: blur(20px);
+    max-height: 520px;
+  }
+
+  .tasks-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+
+  .tasks-header h2 {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+  }
+
+  .task-count {
+    font-size: 0.75rem;
+    color: var(--neon-current);
+    font-family: 'Orbitron', sans-serif;
+    transition: color var(--transition-speed);
+  }
+
+  .task-input-area {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .task-input {
+    flex: 1;
+    padding: 10px 16px;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    color: var(--text-primary);
+    font-family: 'Inter', sans-serif;
+    font-size: 0.85rem;
+    outline: none;
+    transition: all 0.3s;
+  }
+
+  .task-input:focus {
+    border-color: var(--neon-current);
+    box-shadow: 0 0 15px var(--neon-glow);
+    transition: border-color var(--transition-speed), box-shadow var(--transition-speed);
+  }
+
+  .task-input::placeholder { color: var(--text-secondary); opacity: 0.5; }
+
+  .btn-add {
+    width: 42px;
+    height: 42px;
+    border: none;
+    border-radius: 12px;
+    background: linear-gradient(135deg, var(--neon-current), var(--neon-accent));
+    color: white;
+    font-size: 1.3rem;
+    cursor: pointer;
+    transition: all 0.3s, background var(--transition-speed);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .btn-add:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 20px var(--neon-glow);
+  }
+
+  .tasks-list {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 4px;
+  }
+
+  .tasks-list::-webkit-scrollbar { width: 4px; }
+  .tasks-list::-webkit-scrollbar-track { background: transparent; }
+  .tasks-list::-webkit-scrollbar-thumb {
+    background: rgba(255,255,255,0.1);
+    border-radius: 2px;
+  }
+
+  .task-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    margin-bottom: 8px;
+    background: rgba(255,255,255,0.03);
+    border-radius: 12px;
+    border: 1px solid rgba(255,255,255,0.04);
+    transition: all 0.3s;
+    animation: taskSlideIn 0.4s ease-out;
+  }
+
+  @keyframes taskSlideIn {
+    from { opacity: 0; transform: translateX(-20px); }
+    to { opacity: 1; transform: translateX(0); }
+  }
+
+  .task-item:hover {
+    background: rgba(255,255,255,0.06);
+    border-color: rgba(255,255,255,0.08);
+  }
+
+  .task-item.completed {
+    opacity: 0.4;
+  }
+
+  .task-item.completed .task-text {
+    text-decoration: line-through;
+  }
+
+  .task-checkbox {
+    width: 20px;
+    height: 20px;
+    border-radius: 6px;
+    border: 2px solid rgba(255,255,255,0.15);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.3s;
+    background: transparent;
+  }
+
+  .task-checkbox:hover {
+    border-color: var(--neon-current);
+    transition: border-color var(--transition-speed);
+  }
+
+  .task-checkbox.checked {
+    background: var(--neon-current);
+    border-color: var(--neon-current);
+    transition: background var(--transition-speed), border-color var(--transition-speed);
+  }
+
+  .task-checkbox.checked::after {
+    content: '✓';
+    color: var(--bg-primary);
+    font-size: 0.7rem;
+    font-weight: 700;
+  }
+
+  .task-text {
+    flex: 1;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    transition: color 0.3s;
+  }
+
+  .task-delete {
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    opacity: 0;
+    transition: all 0.3s;
+  }
+
+  .task-item:hover .task-delete { opacity: 1; }
+  .task-delete:hover {
+    background: rgba(255, 100, 100, 0.15);
+    color: #ff6b6b;
+  }
+
+  .empty-tasks {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+    color: var(--text-secondary);
+    opacity: 0.5;
+    font-size: 0.85rem;
+    text-align: center;
+  }
+
+  .empty-tasks .empty-icon { font-size: 2.5rem; margin-bottom: 12px; }
+
+  /* ===== НАСТРОЙКИ (нижняя панель) ===== */
+  .settings-section {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 16px 24px;
+    background: var(--bg-card);
+    border-radius: 16px;
+    border: 1px solid rgba(255,255,255,0.05);
+    backdrop-filter: blur(20px);
+    flex-wrap: wrap;
+  }
+
+  .setting-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .setting-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .setting-value {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 0.8rem;
+    color: var(--neon-current);
+    min-width: 30px;
+    text-align: center;
+    transition: color var(--transition-speed);
+  }
+
+  .setting-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    border: 1px solid rgba(255,255,255,0.1);
+    background: rgba(255,255,255,0.04);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+  }
+
+  .setting-btn:hover {
+    background: rgba(255,255,255,0.1);
+    color: var(--text-primary);
+  }
+
+  .setting-divider {
+    width: 1px;
+    height: 24px;
+    background: rgba(255,255,255,0.08);
+  }
+
+  .btn-notifications {
+    padding: 8px 16px;
+    border-radius: 10px;
+    font-size: 0.75rem;
+  }
+
+  /* ===== УВЕДОМЛЕНИЕ (кастомное) ===== */
+  .toast {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 16px 24px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--neon-current);
+    border-radius: 16px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    z-index: 1000;
+    transform: translateX(120%);
+    transition: transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                border-color var(--transition-speed);
+    box-shadow: 0 10px 40px rgba(0,0,0,0.4), 0 0 20px var(--neon-glow);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: 350px;
+  }
+
+  .toast.show { transform: translateX(0); }
+
+  .toast-icon { font-size: 1.3rem; }
+
+  /* ===== GAMIFICATION: LEVEL UP ===== */
+  .level-up-overlay {
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  .level-up-overlay.show {
+    opacity: 1;
+  }
+
+  .level-up-text {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 3rem;
+    font-weight: 900;
+    color: var(--neon-gold);
+    text-shadow: 0 0 40px rgba(255, 215, 0, 0.5);
+    animation: levelUpPop 1.5s ease-out forwards;
+  }
+
+  @keyframes levelUpPop {
+    0% { transform: scale(0.5); opacity: 0; }
+    30% { transform: scale(1.3); opacity: 1; }
+    60% { transform: scale(1); opacity: 1; }
+    100% { transform: scale(1) translateY(-30px); opacity: 0; }
+  }
+
+  /* ===== XP BAR ===== */
+  .xp-section {
+    margin-top: 8px;
+    width: 200px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .xp-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.65rem;
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+  }
+
+  .xp-bar {
+    width: 100%;
+    height: 6px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .xp-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--neon-gold), #ffaa00);
+    border-radius: 3px;
+    transition: width 0.5s ease-out;
+    box-shadow: 0 0 8px rgba(255, 215, 0, 0.3);
+  }
+
+  /* ===== АДАПТИВНОСТЬ ===== */
+  @media (max-width: 900px) {
+    .app-container {
+      grid-template-columns: 1fr;
+      max-width: 500px;
+    }
+
+    .header { grid-column: 1; }
+    .settings-section { grid-column: 1; }
+
+    .jelly-timer-section,
+    .tasks-section {
+      max-height: none;
+    }
+  }
+
+  @media (max-width: 500px) {
+    .timer-time { font-size: 3rem; }
+    .header h1 { font-size: 1rem; }
+    .header-stats { gap: 8px; }
+    .stat-badge { padding: 4px 10px; font-size: 0.7rem; }
+  }
 </style>
 </head>
 <body>
 
-  <div class="jelly-wrap">
-    <div class="jelly" id="jelly">
-      <div class="tentacles">
-        <div class="ten"></div><div class="ten"></div><div class="ten"></div><div class="ten"></div><div class="ten"></div>
+<!-- Фоновые частицы -->
+<div class="particles-bg" id="particles"></div>
+
+<!-- Toast уведомление -->
+<div class="toast" id="toast">
+  <span class="toast-icon" id="toastIcon">🪼</span>
+  <span id="toastText">Время отдохнуть!</span>
+</div>
+
+<!-- Level Up оверлей -->
+<div class="level-up-overlay" id="levelUpOverlay">
+  <div class="level-up-text" id="levelUpText">⬆ LEVEL UP!</div>
+</div>
+
+<div class="app-container">
+
+  <!-- ШАПКА -->
+  <header class="header">
+    <h1>🪼 Jelly Focus</h1>
+    <div class="header-stats">
+      <div class="stat-badge">
+        <span class="stat-icon">🔥</span>
+        <span>Серия:</span>
+        <span class="stat-value" id="streakCount">0</span>
+      </div>
+      <div class="stat-badge">
+        <span class="stat-icon">⭐</span>
+        <span>Уровень:</span>
+        <span class="stat-value" id="levelDisplay">1</span>
+      </div>
+      <div class="stat-badge">
+        <span class="stat-icon">✅</span>
+        <span>Задач:</span>
+        <span class="stat-value" id="completedTasksCount">0</span>
       </div>
     </div>
-  </div>
+  </header>
 
-  <div class="xp-wrap">
-    <div class="xp-meta"><span id="lvlDisp">Ур. 1</span><span id="xpDisp">0 / 100 XP</span></div>
-    <div class="xp-bar"><div class="xp-fill" id="xpFill"></div></div>
-  </div>
-  <div class="stats">
-    <div class="stat">🔥 Серия: <span id="streak">0</span></div>
-    <div class="stat">✅ Задач: <span id="doneTasks">0</span></div>
-  </div>
+  <!-- СЕКЦИЯ МЕДУЗЫ И ТАЙМЕРА -->
+  <section class="jelly-timer-section">
+    <div class="jellyfish-container">
+      <div class="jellyfish" id="jellyfish">
+        <div class="jelly-dome"></div>
+        <div class="jelly-eyes">
+          <div class="jelly-eye"></div>
+          <div class="jelly-eye"></div>
+        </div>
+        <div class="jelly-mouth"></div>
+        <div class="tentacles">
+          <div class="tentacle tentacle-short"></div>
+          <div class="tentacle tentacle-long"></div>
+          <div class="tentacle tentacle-tiny"></div>
+          <div class="tentacle tentacle-long"></div>
+          <div class="tentacle tentacle-short"></div>
+        </div>
+      </div>
+    </div>
 
-  <div class="timer-ui">
-    <div class="phase" id="phaseTxt">ФОКУС</div>
-    <div class="time" id="timeDisp">25:00</div>
-    <div class="progress-bg"><div class="progress-bar" id="progBar"></div></div>
-  </div>
+    <div class="timer-display">
+      <div class="timer-phase" id="timerPhase">Фокус</div>
+      <div class="timer-time" id="timerDisplay">25:00</div>
+      <div class="timer-progress">
+        <div class="timer-progress-bar" id="progressBar" style="width: 100%"></div>
+      </div>
+    </div>
 
-  <div class="controls">
-    <button class="btn primary" id="btnStart">▶ Старт</button>
-    <button class="btn" id="btnReset">↺</button>
-  </div>
+    <div class="timer-controls">
+      <button class="btn btn-primary" id="btnStart" onclick="toggleTimer()">▶ Старт</button>
+      <button class="btn btn-secondary" id="btnReset" onclick="resetTimer()">↺ Сброс</button>
+      <button class="btn btn-secondary" id="btnSkip" onclick="skipPhase()">⏭ Пропустить</button>
+    </div>
 
-  <div class="tasks-h">
-    <span>📋 Задачи сессии</span>
-    <span id="taskCount">0 / 0</span>
-  </div>
-  <div class="task-inputs">
-    <input type="text" id="taskIn" placeholder="Добавить задачу...">
-    <button class="btn" id="btnAdd">+</button>
-  </div>
-  <div class="task-list" id="taskList">
-    <div class="empty">Нет задач. Добавьте первую! 🎯</div>
-  </div>
+    <!-- XP Bar -->
+    <div class="xp-section">
+      <div class="xp-label">
+        <span id="xpLabel">XP: 0 / 100</span>
+        <span>Ур. <span id="levelXp">1</span></span>
+      </div>
+      <div class="xp-bar">
+        <div class="xp-fill" id="xpFill" style="width: 0%"></div>
+      </div>
+    </div>
+  </section>
 
-  <div class="settings">
-    <span>Работа</span>
-    <button class="s-btn" id="workMinus">-</button>
-    <span class="s-val" id="wVal">25</span>
-    <button class="s-btn" id="workPlus">+</button>
-    <span style="margin-left:8px">Отдых</span>
-    <button class="s-btn" id="restMinus">-</button>
-    <span class="s-val" id="rVal">5</span>
-    <button class="s-btn" id="restPlus">+</button>
-  </div>
+  <!-- ПАНЕЛЬ ЗАДАЧ -->
+  <section class="tasks-section">
+    <div class="tasks-header">
+      <h2>📋 Задачи</h2>
+      <span class="task-count" id="taskCount">0 / 0</span>
+    </div>
+    <div class="task-input-area">
+      <input type="text" class="task-input" id="taskInput"
+             placeholder="Добавить задачу..." maxlength="100"
+             onkeydown="if(event.key==='Enter')addTask()">
+      <button class="btn-add" onclick="addTask()">+</button>
+    </div>
+    <div class="tasks-list" id="tasksList">
+      <div class="empty-tasks" id="emptyTasks">
+        <div class="empty-icon">🎯</div>
+        <div>Добавьте задачи для<br>текущей сессии фокуса</div>
+      </div>
+    </div>
+  </section>
 
-  <div class="lvl-up" id="lvlAnim">⬆ LEVEL UP!</div>
-  <script src="popup.js"></script>
+  <!-- НАСТРОЙКИ -->
+  <section class="settings-section">
+    <div class="setting-group">
+      <span class="setting-label">Фокус</span>
+      <button class="setting-btn" onclick="adjustTime('work', -1)">−</button>
+      <span class="setting-value" id="workDuration">25</span>
+      <button class="setting-btn" onclick="adjustTime('work', 1)">+</button>
+      <span class="setting-label">мин</span>
+    </div>
+
+    <div class="setting-divider"></div>
+
+    <div class="setting-group">
+      <span class="setting-label">Отдых</span>
+      <button class="setting-btn" onclick="adjustTime('rest', -1)">−</button>
+      <span class="setting-value" id="restDuration">5</span>
+      <button class="setting-btn" onclick="adjustTime('rest', 1)">+</button>
+      <span class="setting-label">мин</span>
+    </div>
+
+    <div class="setting-divider"></div>
+
+    <div class="setting-group">
+      <span class="setting-label">Авто-старт отдыха</span>
+      <button class="setting-btn" id="autoRestBtn" onclick="toggleAutoRest()"
+              style="color: var(--neon-rest); border-color: rgba(0,255,213,0.3);">ВКЛ</button>
+    </div>
+
+    <div class="setting-divider"></div>
+
+    <button class="btn btn-secondary btn-notifications" id="btnNotifications"
+            onclick="requestNotificationPermission()">
+      🔔 Уведомления
+    </button>
+  </section>
+
+</div>
+
+<script>
+// ===== СОСТОЯНИЕ ПРИЛОЖЕНИЯ =====
+const state = {
+  isRunning: false,
+  isWorkPhase: true,
+  timeLeft: 25 * 60,
+  totalTime: 25 * 60,
+  workDuration: 25,
+  restDuration: 5,
+  timerInterval: null,
+  tasks: [],
+  completedTasks: 0,
+  completedPomodoros: 0,
+  streak: 0,
+  xp: 0,
+  level: 1,
+  xpToNext: 100,
+  autoRest: true,
+  notificationsEnabled: false,
+  soundEnabled: true
+};
+
+// ===== DOM ЭЛЕМЕНТЫ =====
+const $ = id => document.getElementById(id);
+const timerDisplay = $('timerDisplay');
+const timerPhase = $('timerPhase');
+const progressBar = $('progressBar');
+const btnStart = $('btnStart');
+const jellyfish = $('jellyfish');
+const root = document.documentElement;
+
+// ===== ТАЙМЕР =====
+function toggleTimer() {
+  if (state.isRunning) {
+    pauseTimer();
+  } else {
+    startTimer();
+  }
+}
+
+function startTimer() {
+  state.isRunning = true;
+  btnStart.textContent = '⏸ Пауза';
+
+  state.timerInterval = setInterval(() => {
+    state.timeLeft--;
+    updateDisplay();
+
+    if (state.timeLeft <= 0) {
+      clearInterval(state.timerInterval);
+      state.isRunning = false;
+      onCompletePhase();
+    }
+  }, 1000);
+}
+
+function pauseTimer() {
+  state.isRunning = false;
+  clearInterval(state.timerInterval);
+  btnStart.textContent = '▶ Старт';
+}
+
+function resetTimer() {
+  pauseTimer();
+  state.isWorkPhase = true;
+  state.timeLeft = state.workDuration * 60;
+  state.totalTime = state.workDuration * 60;
+  updateDisplay();
+  setPhaseColors(true);
+}
+
+function skipPhase() {
+  pauseTimer();
+  state.isWorkPhase = !state.isWorkPhase;
+
+  if (state.isWorkPhase) {
+    state.timeLeft = state.workDuration * 60;
+    state.totalTime = state.workDuration * 60;
+  } else {
+    state.timeLeft = state.restDuration * 60;
+    state.totalTime = state.restDuration * 60;
+  }
+
+  updateDisplay();
+  setPhaseColors(state.isWorkPhase);
+}
+
+function onCompletePhase() {
+  if (state.isWorkPhase) {
+    // Завершена работа — начисляем XP
+    state.completedPomodoros++;
+    state.streak++;
+    const xpGain = 50 + Math.floor(state.completedPomodoros / 3) * 10;
+    gainXP(xpGain);
+    showToast('🎉', `Помодор #${state.completedPomodoros} завершён! +${xpGain} XP`);
+    playSound('complete');
+
+    if (state.notificationsEnabled) {
+      try {
+        new Notification('🪼 Jelly Focus', {
+          body: `Помодор #${state.completedPomodoros} завершён! Время отдохнуть.`,
+          icon: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🪼</text></svg>'
+        });
+      } catch(e) {}
+    }
+
+    // Переход к отдыху
+    state.isWorkPhase = false;
+    state.timeLeft = state.restDuration * 60;
+    state.totalTime = state.restDuration * 60;
+    setPhaseColors(false);
+    updateDisplay();
+
+    if (state.autoRest) {
+      setTimeout(() => startTimer(), 1500);
+    }
+
+  } else {
+    // Завершён отдых — переход к работе
+    state.isWorkPhase = true;
+    state.timeLeft = state.workDuration * 60;
+    state.totalTime = state.workDuration * 60;
+    setPhaseColors(true);
+    updateDisplay();
+    showToast('💪', 'Отдых окончен! Время фокусироваться.');
+    playSound('restEnd');
+
+    if (state.notificationsEnabled) {
+      try {
+        new Notification('🪼 Jelly Focus', {
+          body: 'Отдых окончен! Время для нового помодора.',
+          icon: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🪼</text></svg>'
+        });
+      } catch(e) {}
+    }
+  }
+
+  btnStart.textContent = '▶ Старт';
+  saveState();
+}
+
+function updateDisplay() {
+  const mins = Math.floor(state.timeLeft / 60);
+  const secs = state.timeLeft % 60;
+  timerDisplay.textContent = `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+
+  const progress = (state.timeLeft / state.totalTime) * 100;
+  progressBar.style.width = `${progress}%`;
+
+  // Обновляем title страницы
+  const phase = state.isWorkPhase ? '🔴 Фокус' : '🟢 Отдых';
+  document.title = `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')} — ${phase} | Jelly Focus`;
+}
+
+function setPhaseColors(isWork) {
+  if (isWork) {
+    root.style.setProperty('--neon-current', 'var(--neon-work)');
+    root.style.setProperty('--neon-glow', 'var(--neon-work-glow)');
+    timerPhase.textContent = 'Фокус';
+    jellyfish.classList.remove('resting');
+  } else {
+    root.style.setProperty('--neon-current', 'var(--neon-rest)');
+    root.style.setProperty('--neon-glow', 'var(--neon-rest-glow)');
+    timerPhase.textContent = 'Отдых';
+    jellyfish.classList.add('resting');
+  }
+
+  // Обновляем цвет фонового свечения
+  const glowEl = document.querySelector('.jelly-timer-section::before');
+  // CSS custom property handles the transition
+}
+
+// ===== ГЕЙМИФИКАЦИЯ =====
+function gainXP(amount) {
+  state.xp += amount;
+
+  while (state.xp >= state.xpToNext) {
+    state.xp -= state.xpToNext;
+    state.level++;
+    state.xpToNext = Math.floor(state.xpToNext * 1.3);
+    showLevelUp();
+    $('levelDisplay').textContent = state.level;
+    $('levelXp').textContent = state.level;
+  }
+
+  updateXPBar();
+  $('streakCount').textContent = state.streak;
+}
+
+function updateXPBar() {
+  const pct = (state.xp / state.xpToNext) * 100;
+  $('xpFill').style.width = `${pct}%`;
+  $('xpLabel').textContent = `XP: ${state.xp} / ${state.xpToNext}`;
+}
+
+function showLevelUp() {
+  const overlay = $('levelUpOverlay');
+  const text = $('levelUpText');
+  text.textContent = `⬆ LEVEL ${state.level}!`;
+  overlay.classList.add('show');
+  playSound('levelup');
+
+  setTimeout(() => overlay.classList.remove('show'), 2000);
+}
+
+// ===== ЗВУКИ (Web Audio API) =====
+let audioCtx = null;
+
+function getAudioContext() {
+  if (!audioCtx) {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  return audioCtx;
+}
+
+function playSound(type) {
+  if (!state.soundEnabled) return;
+  const ctx = getAudioContext();
+
+  if (type === 'complete') {
+    // Мелодичный звук завершения
+    const notes = [523.25, 659.25, 783.99, 1046.50];
+    notes.forEach((freq, i) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(freq, ctx.currentTime + i * 0.15);
+      gain.gain.setValueAtTime(0.15, ctx.currentTime + i * 0.15);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + i * 0.15 + 0.4);
+      osc.start(ctx.currentTime + i * 0.15);
+      osc.stop(ctx.currentTime + i * 0.15 + 0.4);
+    });
+  }
+
+  else if (type === 'restEnd') {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'triangle';
+    osc.frequency.setValueAtTime(440, ctx.currentTime);
+    osc.frequency.linearRampToValueAtTime(880, ctx.currentTime + 0.3);
+    gain.gain.setValueAtTime(0.12, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.5);
+  }
+
+  else if (type === 'levelup') {
+    const notes = [523.25, 659.25, 783.99, 1046.50, 1318.51];
+    notes.forEach((freq, i) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(freq, ctx.currentTime + i * 0.1);
+      gain.gain.setValueAtTime(0.18, ctx.currentTime + i * 0.1);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + i * 0.1 + 0.5);
+      osc.start(ctx.currentTime + i * 0.1);
+      osc.stop(ctx.currentTime + i * 0.1 + 0.5);
+      // Добавляем обертон
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.connect(gain2);
+      gain2.connect(ctx.destination);
+      osc2.type = 'triangle';
+      osc2.frequency.setValueAtTime(freq * 2, ctx.currentTime + i * 0.1);
+      gain2.gain.setValueAtTime(0.06, ctx.currentTime + i * 0.1);
+      gain2.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + i * 0.1 + 0.3);
+      osc2.start(ctx.currentTime + i * 0.1);
+      osc2.stop(ctx.currentTime + i * 0.1 + 0.3);
+    });
+  }
+}
+
+// ===== УВЕДОМЛЕНИЯ =====
+function requestNotificationPermission() {
+  if (!('Notification' in window)) {
+    showToast('⚠️', 'Ваш браузер не поддерживает уведомления');
+    return;
+  }
+
+  Notification.requestPermission().then(perm => {
+    if (perm === 'granted') {
+      state.notificationsEnabled = true;
+      $('btnNotifications').textContent = '🔔 Включены';
+      $('btnNotifications').style.borderColor = 'rgba(0,255,213,0.3)';
+      $('btnNotifications').style.color = 'var(--neon-rest)';
+      showToast('✅', 'Уведомления включены!');
+    } else {
+      state.notificationsEnabled = false;
+      $('btnNotifications').textContent = '🔕 Откл.';
+      showToast('ℹ️', 'Уведомления отклонены');
+    }
+  });
+}
+
+// ===== TOAST =====
+function showToast(icon, text) {
+  const toast = $('toast');
+  $('toastIcon').textContent = icon;
+  $('toastText').textContent = text;
+  toast.classList.add('show');
+  setTimeout(() => toast.classList.remove('show'), 4000);
+}
+
+// ===== ЗАДАЧИ =====
+function addTask() {
+  const input = $('taskInput');
+  const text = input.value.trim();
+  if (!text) return;
+
+  const task = {
+    id: Date.now(),
+    text,
+    completed: false
+  };
+
+  state.tasks.push(task);
+  input.value = '';
+  renderTasks();
+}
+
+function toggleTask(id) {
+  const task = state.tasks.find(t => t.id === id);
+  if (!task) return;
+
+  task.completed = !task.completed;
+
+  if (task.completed) {
+    state.completedTasks++;
+    gainXP(15);
+    $('completedTasksCount').textContent = state.completedTasks;
+  } else {
+    state.completedTasks--;
+    $('completedTasksCount').textContent = state.completedTasks;
+  }
+
+  renderTasks();
+  saveState();
+}
+
+function deleteTask(id) {
+  const idx = state.tasks.findIndex(t => t.id === id);
+  if (idx === -1) return;
+
+  if (state.tasks[idx].completed) {
+    state.completedTasks--;
+    $('completedTasksCount').textContent = state.completedTasks;
+  }
+
+  state.tasks.splice(idx, 1);
+  renderTasks();
+}
+
+function renderTasks() {
+  const list = $('tasksList');
+  const completed = state.tasks.filter(t => t.completed).length;
+  $('taskCount').textContent = `${completed} / ${state.tasks.length}`;
+
+  if (state.tasks.length === 0) {
+    list.innerHTML = `
+      <div class="empty-tasks">
+        <div class="empty-icon">🎯</div>
+        <div>Добавьте задачи для<br>текущей сессии фокуса</div>
+      </div>`;
+    return;
+  }
+
+  list.innerHTML = state.tasks.map(task => `
+    <div class="task-item ${task.completed ? 'completed' : ''}" data-id="${task.id}">
+      <div class="task-checkbox ${task.completed ? 'checked' : ''}"
+           onclick="toggleTask(${task.id})"></div>
+      <span class="task-text">${escapeHTML(task.text)}</span>
+      <button class="task-delete" onclick="deleteTask(${task.id})">✕</button>
+    </div>
+  `).join('');
+}
+
+function escapeHTML(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// ===== НАСТРОЙКИ ВРЕМЕНИ =====
+function adjustTime(type, delta) {
+  if (type === 'work') {
+    state.workDuration = Math.max(5, Math.min(60, state.workDuration + delta));
+    $('workDuration').textContent = state.workDuration;
+    if (state.isWorkPhase && !state.isRunning) {
+      state.timeLeft = state.workDuration * 60;
+      state.totalTime = state.workDuration * 60;
+      updateDisplay();
+    }
+  } else {
+    state.restDuration = Math.max(1, Math.min(30, state.restDuration + delta));
+    $('restDuration').textContent = state.restDuration;
+    if (!state.isWorkPhase && !state.isRunning) {
+      state.timeLeft = state.restDuration * 60;
+      state.totalTime = state.restDuration * 60;
+      updateDisplay();
+    }
+  }
+  saveState();
+}
+
+function toggleAutoRest() {
+  state.autoRest = !state.autoRest;
+  const btn = $('autoRestBtn');
+  if (state.autoRest) {
+    btn.textContent = 'ВКЛ';
+    btn.style.color = 'var(--neon-rest)';
+    btn.style.borderColor = 'rgba(0,255,213,0.3)';
+  } else {
+    btn.textContent = 'ВЫКЛ';
+    btn.style.color = 'var(--text-secondary)';
+    btn.style.borderColor = 'rgba(255,255,255,0.1)';
+  }
+}
+
+// ===== СОХРАНЕНИЕ / ЗАГРУЗКА =====
+function saveState() {
+  const data = {
+    completedPomodoros: state.completedPomodoros,
+    streak: state.streak,
+    xp: state.xp,
+    level: state.level,
+    xpToNext: state.xpToNext,
+    completedTasks: state.completedTasks,
+    tasks: state.tasks,
+    workDuration: state.workDuration,
+    restDuration: state.restDuration,
+    autoRest: state.autoRest
+  };
+  localStorage.setItem('jellyFocus', JSON.stringify(data));
+}
+
+function loadState() {
+  const raw = localStorage.getItem('jellyFocus');
+  if (!raw) return;
+
+  try {
+    const data = JSON.parse(raw);
+    state.completedPomodoros = data.completedPomodoros || 0;
+    state.streak = data.streak || 0;
+    state.xp = data.xp || 0;
+    state.level = data.level || 1;
+    state.xpToNext = data.xpToNext || 100;
+    state.completedTasks = data.completedTasks || 0;
+    state.tasks = data.tasks || [];
+    state.workDuration = data.workDuration || 25;
+    state.restDuration = data.restDuration || 5;
+    state.autoRest = data.autoRest !== undefined ? data.autoRest : true;
+
+    $('workDuration').textContent = state.workDuration;
+    $('restDuration').textContent = state.restDuration;
+    $('levelDisplay').textContent = state.level;
+    $('levelXp').textContent = state.level;
+    $('streakCount').textContent = state.streak;
+    $('completedTasksCount').textContent = state.completedTasks;
+
+    if (!state.autoRest) {
+      const btn = $('autoRestBtn');
+      btn.textContent = 'ВЫКЛ';
+      btn.style.color = 'var(--text-secondary)';
+      btn.style.borderColor = 'rgba(255,255,255,0.1)';
+    }
+
+    updateXPBar();
+    renderTasks();
+
+    state.timeLeft = state.workDuration * 60;
+    state.totalTime = state.workDuration * 60;
+    updateDisplay();
+
+  } catch(e) {
+    console.warn('Failed to load state:', e);
+  }
+}
+
+// ===== ФОНОВЫЕ ЧАСТИЦЫ =====
+function createParticles() {
+  const container = $('particles');
+  for (let i = 0; i < 25; i++) {
+    const p = document.createElement('div');
+    p.className = 'particle';
+    const size = Math.random() * 6 + 2;
+    p.style.width = size + 'px';
+    p.style.height = size + 'px';
+    p.style.left = Math.random() * 100 + '%';
+    p.style.animationDuration = (Math.random() * 15 + 10) + 's';
+    p.style.animationDelay = (Math.random() * 10) + 's';
+    container.appendChild(p);
+  }
+}
+
+// ===== ИНИЦИАЛИЗАЦИЯ =====
+function init() {
+  createParticles();
+  loadState();
+  updateDisplay();
+  setPhaseColors(state.isWorkPhase);
+
+  // Запрос разрешений на уведомления при первом запуске
+  if ('Notification' in window && Notification.permission === 'default') {
+    // Можно раскомментировать для авто-запроса:
+    // requestNotificationPermission();
+  }
+}
+
+init();
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a richer, self-contained Pomodoro experience in the extension popup by replacing the compact UI with the full Jelly Focus layout and behavior. 
- Add gamification, task management, notifications and nicer visuals so the popup can act as a lightweight single-file app.

### Description
- Replaced `popup.html` content with a full neon-themed layout including header stats, jellyfish timer section, particles background, tasks panel, settings row, toast notifications, level-up overlay and XP bar. 
- Inlined JavaScript implements the timer lifecycle, phase switching (work/rest), XP and leveling, task CRUD, localStorage persistence, Web Audio cues, Notifications API handling, particle generation and initialization. 
- Updated CSS (fonts via Google Fonts, animations, responsive rules) and connected controls (`toggleTimer`, `resetTimer`, `skipPhase`, `adjustTime`, `toggleAutoRest`, `requestNotificationPermission`, etc.).

### Testing
- Verified the new file was written and inspected with `wc -l popup.html` which completed successfully. 
- Inspected the updated file contents with `nl -ba popup.html | sed -n` to confirm the new structure and inline script, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf41427448325b9057a63cc50a73d)