### PR TITLE
Remove invalid ::before selector in popup.html

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1117,9 +1117,7 @@ function setPhaseColors(isWork) {
     jellyfish.classList.add('resting');
   }
 
-  // Обновляем цвет фонового свечения
-  const glowEl = document.querySelector('.jelly-timer-section::before');
-  // CSS custom property handles the transition
+  // Цвет фонового свечения обновляется через CSS custom properties.
 }
 
 // ===== ГЕЙМИФИКАЦИЯ =====


### PR DESCRIPTION
### Motivation
- Prevent a runtime error where `querySelector('.jelly-timer-section::before')` attempted to select a CSS pseudo-element (which is not selectable) and could interrupt phase-switching logic.

### Description
- Replace the invalid `querySelector` call in `setPhaseColors` inside `popup.html` with a short clarifying comment noting that the glow is updated via CSS custom properties.

### Testing
- Confirmed the selector was removed by searching with `rg "querySelector('\.jelly-timer-section::before')" popup.html`, which returned no matches (success).
- Committed the change and verified the new commit/ref with `git commit` / `git rev-parse`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce399fedf48325b45b0f5430f0fc9a)